### PR TITLE
Removal of OpenTournamentEntry.umap for replacement

### DIFF
--- a/Content/OpenTournament/Levels/OpenTournamentEntry.umap
+++ b/Content/OpenTournament/Levels/OpenTournamentEntry.umap
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:afec191c71fa589624c5ed4d267b92174e8d5bf0b9286fc501ec24d4c8c6cd9a
-size 1039707


### PR DESCRIPTION
This file is being removed as it was committed in a compiled state and shouldn't have been, an unaltered replacement for this will be added in the next commit