### PR TITLE
Include Jira Link within readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,6 @@ out as many C++ code based features as was possible for the project, and we apol
 
 NOTICE REGARDING USER STORIES, AND TASKS:
 -- User stories, and tasks can be seen in the user stories document within the group 13 documentation folder, in addition to this, a link to our Jira board we have been using is included at this link: https://ceg-4110-project.atlassian.net/secure/RapidBoard.jspa?rapidView=1&projectKey=C4P&view=planning&selectedIssue=C4P-59&issueLimit=100
+
+NOTICE REGARDING ACTUALLY RUNNING OPEN TOURNAMENT:
+-- The way the original owners of the Open Tournament repo intended to run the project is to locally clone the repo, and run things via generating a .sln file from the 'OpenTournament.uproject' file in the first level of the repo. This will require unreal engine 4.25, and further details can be seen within the original README file from the original devs within our group 13 documentation folder in the README.md file there.

--- a/README.md
+++ b/README.md
@@ -17,3 +17,6 @@ NOTICE REGARDING PROJECT DIRECTION CHANGE:
 -- Up until the date of 4/14/2021 most of our project primarily regarded UI changes being made via Uasset files. After some email correspondance, we realized there had been a few 
 miscommunication problems on our end, and we had poured far too much time working in the unreal editor on these files. The last two weeks of project work were all related to churning
 out as many C++ code based features as was possible for the project, and we apologize for the misunderstanding.
+
+NOTICE REGARDING USER STORIES, AND TASKS:
+-- User stories, and tasks can be seen in the user stories document within the group 13 documentation folder, in addition to this, a link to our Jira board we have been using is included at this link: https://ceg-4110-project.atlassian.net/secure/RapidBoard.jspa?rapidView=1&projectKey=C4P&view=planning&selectedIssue=C4P-59&issueLimit=100


### PR DESCRIPTION
Just a quick update to readme.md to include a link to our jira board in addition to the user stories doc within our documentation folder. Only having this as a pull request as our master branch is protected